### PR TITLE
hotfix: dont write to destroyed sockets

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -94,12 +94,17 @@ class EmailValidator {
 
     return new Promise(resolve => {
       const socket = net.connect(25, mxRecord);
+      let resTimeout;
 
       const ret = result => {
         if (ret.resolved) return;
 
-        socket.write('QUIT\r\n');
-        socket.end();
+        if (!socket.destroyed) {
+          socket.write('QUIT\r\n');
+          socket.end();
+        }
+
+        clearTimeout(resTimeout);
         resolve(result);
         ret.resolved = true;
       };
@@ -123,7 +128,7 @@ class EmailValidator {
 
       socket.on('error', () => ret(null));
 
-      setTimeout(() => ret(null), timeout);
+      resTimeout = setTimeout(() => ret(null), timeout);
     });
   }
 }


### PR DESCRIPTION
On an ECONNREFUSED, for example, we'll attempt a socket.write of QUIT, which will error out because there's no socket, which in turn calls the error callback again, etc., etc.